### PR TITLE
ci: pin GitHub Actions to SHAs, add Dependabot cooldown and SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.head_ref }}
 
@@ -30,6 +30,6 @@ jobs:
           args: --config=.php-cs-fixer.dist.php --allow-risky=yes
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: Fix styling ${{ github.sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+These package versions are security-supported.
+
+| Version | Supported          |
+|---------|--------------------|
+| > 1.x.x | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+You can report a vulnerability by sending an email to [watheq[dot]alshowaiter[at]gmail[dot]com](mailto:watheq.alshowaiter@gmail.com).
+
+Thank you for helping to keep this package secure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ These package versions are security-supported.
 
 | Version | Supported          |
 |---------|--------------------|
-| > 1.x.x | :white_check_mark: |
+| 1.x     | :white_check_mark: |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary
- Pin all `uses:` GitHub Actions references in `.github/workflows/*.yml` to full 40-char commit SHAs (version kept as trailing comment) to close a supply-chain gap.
- Add `.github/dependabot.yml` with a 7-day `cooldown.default-days` for both the `composer` and `github-actions` ecosystems (file didn't exist before).
- Add `SECURITY.md` with a vulnerability disclosure policy.

Prompted by preparing for scoring on plumbphp.dev — no live score exists for this package yet (it's queued), so this addresses the standard checks the platform evaluates (unpinned actions, missing Dependabot cooldown, missing SECURITY.md) proactively.

Not included: branch protection on `main` (separate decision, tracked outside this PR) and FUNDING.yml (not a security item).

## Test plan
- [x] All workflow/dependabot YAML files validated with `python3 -c "import yaml; yaml.safe_load(open(f))"`
- [ ] CI runs green on this PR (Tests + Formats workflows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)